### PR TITLE
docs: add archived/superseded notice (legacy-retirement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **Archived as of 2026-06-27** — superseded in part by [danstonedev/imu](https://github.com/danstonedev/imu); retained read-only for history.
+>
+> **Salvage note:** `py/hip_inverse_dynamics.py` holds a unique 3-segment (foot→shank→thigh) Newton-Euler inverse-dynamics chain with De Leva anthropometrics, force-plate/insole CoP, and an IMU-only GRF/CoP estimator — found nowhere else in the org (the `imu` successor has only a simpler femur-only model). Salvage `py/hip_inverse_dynamics.py`, `py/pages_pipeline.py`, and `js/gpu/` before relying on the archive. Evidence: [devpt/LEGACY-AUDIT.md](https://github.com/danstonedev/devpt/blob/claude/devpt-portfolio-analysis-whhyrm/LEGACY-AUDIT.md).
+
 # IMU Hip Torque (Browser MVP)
 
 ## GitHub Pages


### PR DESCRIPTION
Adds a top-of-README archived/superseded notice as part of the DevPT org legacy-repo retirement (see [devpt/LEGACY-AUDIT.md](https://github.com/danstonedev/devpt/blob/claude/devpt-portfolio-analysis-whhyrm/LEGACY-AUDIT.md) and devpt PR #26).

**Documentation only and fully reversible** — this PR does not archive or delete anything. The maintainer flips the GitHub Archive toggle manually, after review.

Verdict for this repo: ARCHIVE (M) — dormant; salvage the unique inverse-dynamics code before archiving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuqZTNf948FPJfEnFTHceB

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuqZTNf948FPJfEnFTHceB)_