### PR TITLE
docs: fix archive notice — point lineage at MASH, not the also-archived imu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-> ⚠️ **Archived as of 2026-06-27** — superseded in part by [danstonedev/imu](https://github.com/danstonedev/imu); retained read-only for history.
+> ⚠️ **Archived as of 2026-06-27** — retained read-only for history. Its IMU/biomech lineage is superseded by [danstonedev/MASH](https://github.com/danstonedev/MASH) (TypeScript); note that `danstonedev/imu` is also archived, so it is not a live successor.
 >
-> **Salvage note:** `py/hip_inverse_dynamics.py` holds a unique 3-segment (foot→shank→thigh) Newton-Euler inverse-dynamics chain with De Leva anthropometrics, force-plate/insole CoP, and an IMU-only GRF/CoP estimator — found nowhere else in the org (the `imu` successor has only a simpler femur-only model). Salvage `py/hip_inverse_dynamics.py`, `py/pages_pipeline.py`, and `js/gpu/` before relying on the archive. Evidence: [devpt/LEGACY-AUDIT.md](https://github.com/danstonedev/devpt/blob/claude/devpt-portfolio-analysis-whhyrm/LEGACY-AUDIT.md).
+> **Salvage note:** this repo holds a unique 3-segment (foot→shank→thigh) Newton-Euler inverse-dynamics chain with De Leva anthropometrics, force-plate/insole CoP, and an IMU-only GRF/CoP estimator (`py/hip_inverse_dynamics.py`, `py/pages_pipeline.py`, `js/gpu/`) — found nowhere else in the org and preserved in this repo's git history. Copy it out before reuse. Evidence: [devpt/LEGACY-AUDIT.md](https://github.com/danstonedev/devpt/blob/claude/devpt-portfolio-analysis-whhyrm/LEGACY-AUDIT.md).
 
 # IMU Hip Torque (Browser MVP)
 


### PR DESCRIPTION
The merged archive notice named `danstonedev/imu` as the successor, but `imu` is itself archived — so it was pointing at a tombstone. Corrected: the IMU/biomech lineage successor is `MASH` (TypeScript); the unique inverse-dynamics code is preserved in this repo's own git history. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuqZTNf948FPJfEnFTHceB

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuqZTNf948FPJfEnFTHceB)_